### PR TITLE
Update init.lua to use accurate require path.

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -1,3 +1,3 @@
 return {
-	HotReloader = require(script.Parent.HotReloader),
+	HotReloader = require(script.HotReloader),
 }


### PR DESCRIPTION
# Problem
HotReloader is not a valid path since this is within init.lua

# Solution
Replace the require path.