### PR TITLE
Use !strict mode for HotReloader

### DIFF
--- a/src/HotReloader.lua
+++ b/src/HotReloader.lua
@@ -1,3 +1,4 @@
+--!strict
 local RunService = game:GetService("RunService")
 
 local HotReloader = {}
@@ -12,14 +13,14 @@ function HotReloader.new()
 end
 
 function HotReloader:destroy()
-	for _, listener: RBXScriptSignal in pairs(self._listeners) do
+	for _, listener: RBXScriptConnection in pairs(self._listeners) do
 		listener:Disconnect()
 	end
-	self._listeners = nil
+	self._listeners = {}
 	for _, cloned in pairs(self._clonedModules) do
 		cloned:Destroy()
 	end
-	self._clonedModules = nil
+	self._clonedModules = {}
 end
 
 function HotReloader:listen(module: ModuleScript, callback: (ModuleScript) -> nil, cleanup: (ModuleScript) -> nil)


### PR DESCRIPTION
When set to strict mode, there are a few luau typing errors that were raised.

HotReloader.lua is partially typed, yet strict mode was not enabled. When strict is enabled, the luau analysis raises a few Type Errors:
- setting a previously initialized field (`_listerners`, `_clonedModues`) to nil is not supported. We can clear the table by setting it to an empty array for type safety.
- `listener` within `for _, listener in pairs(self._listeners) do` was incorrectly typed as `RBXScriptSignal` when it should be `RBXScriptConnection`