### PR TITLE
Add support for modules being added or removed

### DIFF
--- a/src/HotReloader.lua
+++ b/src/HotReloader.lua
@@ -1,4 +1,5 @@
 --!strict
+local CollectionService = game:GetService("CollectionService")
 local RunService = game:GetService("RunService")
 
 local HotReloader = {}
@@ -33,7 +34,14 @@ function HotReloader:listen(module: ModuleScript, callback: (ModuleScript) -> ni
 				cleanup(module)
 			end
 
+			if not game:IsAncestorOf(module) then
+				return
+			end
+
 			local cloned = module:Clone()
+
+			CollectionService:AddTag(cloned, "RewireClonedModule")
+
 			cloned.Parent = module.Parent
 			self._clonedModules[module] = cloned
 


### PR DESCRIPTION
- Don't attempt to reload module if it's no longer in the DataModel (it's been removed by Rojo)
- Tag cloned modules with CollectionService tags so that they can be ignored in ChildAdded/ChildRemoved event handlers upstream